### PR TITLE
Optimize import time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MIMEFileExtensions"
 uuid = "6c52b162-0bf1-470e-b8cf-cc2a85579f89"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com> and contributors"]
-version = "0.1.2-DEV"
+version = "0.2.0-DEV"
 
 [compat]
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types
 julia> using MIMEFileExtensions
 
 julia> fileexts_from_mime("image/jpeg")
-("jpeg", "jpg", "jpe")
+3-element Vector{Symbol}:
+ :jpeg
+ :jpg
+ :jpe
 
 julia> mimes_from_fileext("txt")
-("text/plain",)
+1-element Vector{Symbol}:
+ Symbol("text/plain")
 ```
 
 ## See also

--- a/test/MIMEFileExtensionsTests/src/MIMEFileExtensionsTests.jl
+++ b/test/MIMEFileExtensionsTests/src/MIMEFileExtensionsTests.jl
@@ -4,20 +4,25 @@ using Documenter
 using MIMEFileExtensions
 using Test
 
+macro s_str(x::AbstractString)
+    QuoteNode(Symbol(x))
+end
+
 function test_list()
     dict = Dict(row.mime => row.fileexts for row in MIMEFileExtensions.list())
-    @test ("txt", "log") ⊆ dict["text/plain"]
-    @test ("jpeg", "jpg") ⊆ dict["image/jpeg"]
+    @test [s"txt", s"log"] ⊆ dict[s"text/plain"]
+    @test [s"jpeg", s"jpg"] ⊆ dict[s"image/jpeg"]
 end
 
 function test_fileexts_from_mime()
-    @test ("txt", "log") ⊆ fileexts_from_mime("text/plain")
-    @test ("jpeg", "jpg") ⊆ fileexts_from_mime("image/jpeg")
+    @test [s"txt", s"log"] ⊆ fileexts_from_mime(s"text/plain")
+    @test [s"jpeg", s"jpg"] ⊆ fileexts_from_mime("image/jpeg")
+    @test [s"png"] ⊆ fileexts_from_mime(MIME"image/png"())
 end
 
 function test_mimes_from_fileext()
-    @test ("text/plain",) ⊆ MIMEFileExtensions.mimes_from_fileext("txt")
-    @test ("image/jpeg",) ⊆ MIMEFileExtensions.mimes_from_fileext("jpg")
+    @test [s"text/plain"] ⊆ MIMEFileExtensions.mimes_from_fileext(s"txt")
+    @test [s"image/jpeg"] ⊆ MIMEFileExtensions.mimes_from_fileext("jpg")
 end
 
 function test_doctest()


### PR DESCRIPTION
#6 makes loading MIMEFileExtensions (v0.1.1) slow:
```console
$ rm ~/.julia/compiled/v1.7/MIMEFileExtensions/*.ji
$ julia -e '@time using MIMEFileExtensions'
  1.088552 seconds (506.06 k allocations: 29.272 MiB, 36.05% compilation time)
$ ls -lh ~/.julia/compiled/v1.7/MIMEFileExtensions
total 208K
-rw-rw-r-- 1 arakaki arakaki 206K Mar 22 21:47 0i4jm_ydM5K.ji
$ julia -e '@time using MIMEFileExtensions'
  0.425975 seconds (478.77 k allocations: 27.534 MiB, 90.62% compilation time)
$ julia -e '@time using MIMEFileExtensions'
  0.425975 seconds (478.77 k allocations: 27.534 MiB, 90.57% compilation time)
```

It looks like the main reason is that `Tuple{Vararg{String}}` is not a terrible type to represent variable-length content.

Using `Vector{String}`:

```console
$ rm ~/.julia/compiled/v1.7/MIMEFileExtensions/*.ji
$ julia -e '@time using MIMEFileExtensions'
  0.443467 seconds (118.20 k allocations: 8.624 MiB, 19.87% compilation time)
$ ls -lh ~/.julia/compiled/v1.7/MIMEFileExtensions
total 208K
-rw-rw-r-- 1 arakaki arakaki 207K Mar 22 21:16 0i4jm_ydM5K.ji
$ julia -e '@time using MIMEFileExtensions'
  0.097309 seconds (90.92 k allocations: 6.949 MiB, 75.95% compilation time)
$ julia -e '@time using MIMEFileExtensions'
  0.097159 seconds (90.91 k allocations: 6.887 MiB, 75.86% compilation time)
```

Using `Vector{Symbol}` (this PR):

```console
$ rm ~/.julia/compiled/v1.7/MIMEFileExtensions/*.ji
$ julia -e '@time using MIMEFileExtensions'
  0.438848 seconds (112.58 k allocations: 8.364 MiB, 18.68% compilation time)
$ ls -lh ~/.julia/compiled/v1.7/MIMEFileExtensions
total 196K
-rw-rw-r-- 1 arakaki arakaki 193K Mar 22 21:15 0i4jm_ydM5K.ji
$ julia -e '@time using MIMEFileExtensions'
  0.091745 seconds (85.30 k allocations: 6.627 MiB, 74.87% compilation time)
$ julia -e '@time using MIMEFileExtensions'
  0.091200 seconds (85.30 k allocations: 6.627 MiB, 75.03% compilation time)
```

`Vector{Symbol}` is slightly faster and produces a smaller cache.